### PR TITLE
Return notification response to ChannelManager

### DIFF
--- a/src/IonicPushChannel.php
+++ b/src/IonicPushChannel.php
@@ -63,5 +63,7 @@ class IonicPushChannel
         if ($response->getStatusCode() !== 201) {
             throw CouldNotSendNotification::serviceRespondedWithAnError($response);
         }
+        
+        return $response;
     }
 }

--- a/src/IonicPushChannel.php
+++ b/src/IonicPushChannel.php
@@ -63,7 +63,7 @@ class IonicPushChannel
         if ($response->getStatusCode() !== 201) {
             throw CouldNotSendNotification::serviceRespondedWithAnError($response);
         }
-        
+
         return $response;
     }
 }


### PR DESCRIPTION
After the notification is sent to the provider (in this case Ionic) it will return the response.

This response could be useful for logging purposes (logging is already handled by Laravel's [ChannelManager here](https://github.com/laravel/framework/blob/5.3/src/Illuminate/Notifications/ChannelManager.php#L82) ).

The developer will just need to subscribe to the NotificationSent Event (which is [described here in the Laravel docs](https://laravel.com/docs/5.3/notifications#notification-events) ) and ask the NotificationSent event for its response (```$event->response```) and parse that as he pleases.

This response contains i.e. the UUID of the message given by Ionic, which can be used to debug the messages via [Ionic's API](http://docs.ionic.io/api/endpoints/push.html#get-notifications-notification_id)